### PR TITLE
Add getter and setter for calibration data.

### DIFF
--- a/TouchScreen_STM32.cpp
+++ b/TouchScreen_STM32.cpp
@@ -72,6 +72,22 @@ void TouchScreen::calibratePoint(void)
 	} while ( getPoint() );
 }
 /*****************************************************************************/
+void TouchScreen::getCalibrationParameters(int *xmin, int *xmax, int *ymin, int *ymax)
+{
+	*xmin = TouchScreen::xmin;
+	*xmax = TouchScreen::xmax;
+	*ymin = TouchScreen::ymin;
+	*ymax = TouchScreen::ymax;
+}
+/*****************************************************************************/
+void TouchScreen::setCalibrationParameters(int xmin, int xmax, int ymin, int ymax)
+{
+	TouchScreen::xmin = xmin;
+	TouchScreen::xmax = xmax;
+	TouchScreen::ymin = ymin;
+	TouchScreen::ymax = ymax;
+}
+/*****************************************************************************/
 void sortArray(int pos)
 {
 	// it will sort the position in the array from lower to higher value order

--- a/TouchScreen_STM32.h
+++ b/TouchScreen_STM32.h
@@ -20,6 +20,8 @@ class TouchScreen {
 	void rangeSet(int xmax, int ymax);
 	bool getPoint(TSPoint* tsp);
 	void calibratePoint(void);
+	void getCalibrationParameters(int *xmin, int *xmax, int *ymin, int *ymax);
+	void setCalibrationParameters(int xmin, int xmax, int ymin, int ymax);
 	int pressureThreshhold;
 
   private:


### PR DESCRIPTION
Allows calibration data to be stored across reboots, or adjusted (e.g. mirroring an axis)